### PR TITLE
Fix Laplace noise scale to be sensitivity / epsilon

### DIFF
--- a/src/Thesis/Mechanism/Laplace.hs
+++ b/src/Thesis/Mechanism/Laplace.hs
@@ -21,7 +21,7 @@ laplace :: (MonadIO m)
 laplace gen connection (Query e ast) =
   let sql = emitLaplace ast
       aggregation = selectAggregation ast
-      noiseScale = value e / sensitivity aggregation
+      noiseScale = sensitivity aggregation / value e
       (noise, newGen) = generateNoise gen noiseScale
   in do
     trueAnswer <- executeSql connection sql


### PR DESCRIPTION
If I'm not mistaken, then per definition of the Laplace mechanism, noise should be calibrated to `sensitivity / epsilon`. For some reason we implemented scale to be `epsilon / sensitivity` at first.